### PR TITLE
FLOW-1813 Don't use version tags created by newer workflow runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,11 @@ jobs:
         only-output-tags: true
     - run: echo ${{ steps.image-tags.outputs.tag }} ${{ steps.image-tags.outputs.latest_tag }}
     - run: '[[ "${{ steps.build-image.outputs.tag }}" == "${{ steps.image-tags.outputs.tag }}" ]]'
+    - run: git config --global user.email "pipeline@leanix.net" && git config --global user.name "Pipeline" && git commit --allow-empty -m "New concurrent version" && git tag ${{ steps.image-tags.outputs.git_tag }}0
+    - name: use-action-in-output-only-mode
+      id: image-tags-concurrent
+      uses: ./
+      with:
+        only-output-tags: true
+    - run: echo ${{ steps.image-tags-concurrent.outputs.tag }} ${{ steps.image-tags-concurrent.outputs.latest_tag }}
+    - run: '[[ "${{ steps.build-image.outputs.tag }}" == "${{ steps.image-tags-concurrent.outputs.tag }}" ]]'

--- a/dist/index.js
+++ b/dist/index.js
@@ -3600,6 +3600,7 @@ const fs = __webpack_require__(747);
 
         core.setOutput('tag', versionTag);
         core.setOutput('latest_tag', latestTag);
+        core.setOutput('git_tag', versionTagPrefix + nextVersion);
     } catch (e) {
         core.setFailed(e.message);
     }

--- a/index.js
+++ b/index.js
@@ -34,18 +34,33 @@ const fs = require('fs');
 
         // Fetch tags and look for existing one matching the current versionTagPrefix
         await git.fetch(['--tags']);
-        const tagsString = await git.tag(
+        const tagsOfCurrentCommitString = await git.tag(
             [
                 '-l', versionTagPrefix + '*', // Only list tags that start with our version prefix...
-                '--sort', '-v:refname' // ...and sort them in reverse
+                '--points-at', currentCommit, // ...and that point at our current commit...
+                '--sort', '-v:refname' // ...and sort them in reverse in case there is more than one
             ]
         );
 
-        // If we found one, use it to update the current version and set the tagged commit
-        if (tagsString.length > 0) {
-            const tags = tagsString.split('\n');
-            currentVersion=parseInt(tags[0].replace(versionTagPrefix, ''));
-            taggedCommit = await git.show(['--pretty=format:%H', '-s', tags[0]]);
+        if (tagsOfCurrentCommitString.length > 0) {
+            // If the commit is already tagged, we use that tag
+            const tagsOfCurrentCommit = tagsOfCurrentCommitString.split('\n');
+            currentVersion=parseInt(tagsOfCurrentCommit[0].replace(versionTagPrefix, ''));
+            taggedCommit = currentCommit;
+        } else {
+            // Otherwise we determine the latest version tag such that we can create a new tag with an incremented version number
+            const tagsString = await git.tag(
+                [
+                    '-l', versionTagPrefix + '*', // Only list tags that start with our version prefix...
+                    '--sort', '-v:refname' // ...and sort them in reverse
+                ]
+            );
+            // If we found one, use it to update the current version and set the tagged commit
+            if (tagsString.length > 0) {
+                const tags = tagsString.split('\n');
+                currentVersion=parseInt(tags[0].replace(versionTagPrefix, ''));
+                taggedCommit = await git.show(['--pretty=format:%H', '-s', tags[0]]);
+            }
         }
 
         // If we found a tagged commit and it equals the current one, just reuse the version, otherwise tag a new version and push the tag

--- a/index.js
+++ b/index.js
@@ -103,6 +103,7 @@ const fs = require('fs');
 
         core.setOutput('tag', versionTag);
         core.setOutput('latest_tag', latestTag);
+        core.setOutput('git_tag', versionTagPrefix + nextVersion);
     } catch (e) {
         core.setFailed(e.message);
     }


### PR DESCRIPTION
We faced the issue in Team Overflow that merges to master triggering parallel workflows will create newer version tags that are then used in the older still running builds, leading to failures in the kubernetes deployment not finding the version on DockerHub.

While we'll fix having parallel deployments at all via the turnstyle action, this is easier to be realized if we can only insert it in the deploy-to-prod job within the workflow such that other CI workflows won't be affected. 

The change in this PR leads to first looking at tags on the commit of the workflow and only if no such tag exist looking at all commits. Is there a way to test this?